### PR TITLE
Fix time_slot indexing in parse_car_path

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -149,8 +149,8 @@ def proximity_cost(images, states, car_size=(6.4, 14.3), green_channel=1, unnorm
 
 def parse_car_path(path):
     splits = path.split('/')
-    time_slot = splits[4]
-    car_id = int(re.findall('car(\d+).pkl', splits[5])[0])
+    time_slot = splits[-2]
+    car_id = int(re.findall('car(\d+).pkl', splits[-1])[0])
     data_files = {'trajectories-0400-0415': 0,
                   'trajectories-0500-0515': 1,
                   'trajectories-0515-0530': 2}


### PR DESCRIPTION
fixed the indexing (similar to what was done in commit 490c85c). the original indices `4` and `5` are not consistent with the directory structure that is defined in the README, it should be `3` and `4`. But I used the indices `-1` and `-2` so that the code would require less changes in the future if the directory structure changes.