### PR TITLE
corrected the links in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Prediction and Policy-learning Under Uncertainty (PPUU)
-[Gitter chatroom](gitter.im/PPUU), [video summary](youtu.be/X2s7gy3wIYw), [slides](bit.ly/PPUU-slides), [poster](bit.ly/PPUU-poster), [website](bit.ly/PPUU-web).  
+[Gitter chatroom](http://gitter.im/PPUU), [video summary](http://youtu.be/X2s7gy3wIYw), [slides](http://bit.ly/PPUU-slides), [poster](http://bit.ly/PPUU-poster), [website](http://bit.ly/PPUU-web).  
 Implementing [Model-Predictive Policy Learning with Uncertainty Regularization for Driving in Dense Traffic](http://bit.ly/PPUU-article) in [PyTorch](https://pytorch.org).
 
 ![planning](doc/planning.png)


### PR DESCRIPTION
Just noticed that some of the links in the `README` file doesn't work since URLs do not start with `http://`. For example 'Gitter Chatroom' link goes to `https://github.com/Atcold/pytorch-PPUU/blob/master/gitter.im/PPUU` instead of `gitter.im/PPUU`.