### PR TITLE
Minor change in train_cost.py to ensure consistency of the model files 

### DIFF
--- a/train_cost.py
+++ b/train_cost.py
@@ -122,6 +122,9 @@ for i in range(200):
                 'optimizer': optimizer.state_dict(),
                 'n_iter': n_iter}, opt.model_file + '.model')
     if (n_iter/opt.epoch_size) % 10 == 0:
+        torch.save({'model': cost,
+                    'optimizer': optimizer.state_dict(),
+                    'n_iter': n_iter}, opt.model_file + f'.step{n_iter}.model')
         torch.save(model, opt.model_file + f'.step{n_iter}.model')
     model.intype('gpu')
     log_string = f'step {n_iter} | train: {train_loss} | valid: {valid_loss}' 


### PR DESCRIPTION
Intermediate results of the cost model are saved differently than the final cost model. Intermediate results just contain the model object, whereas we save a dictionary containing the model file, optimizer and `n_iter` in the final model file. As a result `train_MPUR.py` do not work if we use intermediate results of the cost model. 