### PR TITLE
Implemented tensorboard support for forward model training

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,9 +11,11 @@ dependencies:
   - matplotlib
   - pip
   - jupyter
+  - scikit-learn
+  - scikit-image
   - pip:
     - gym
     - pygame
-    - scikit-learn
     - jupytext
     - ipdb
+    - tb-nightly

--- a/environment.yaml
+++ b/environment.yaml
@@ -19,3 +19,4 @@ dependencies:
     - jupytext
     - ipdb
     - tb-nightly
+    - moviepy

--- a/eval_policy.py
+++ b/eval_policy.py
@@ -50,7 +50,7 @@ parser.add_argument('-mfile', type=str, default=M1, help=' ')
 parser.add_argument('-value_model', type=str, default='', help=' ')
 parser.add_argument('-policy_model', type=str, default='', help=' ')
 parser.add_argument('-save_sim_video', action='store_true', help='Save simulator video in <frames> info attribute')
-parser.add_argument('-tensorboard_dir', type=str, default='models/policy_networks',
+parser.add_argument('-tensorboard_dir', type=str, default='models/planning_results',
                     help='path to the directory where to save tensorboard log. If passed empty path' \
                          ' no logs are saved.')
 

--- a/eval_policy.py
+++ b/eval_policy.py
@@ -50,6 +50,9 @@ parser.add_argument('-mfile', type=str, default=M1, help=' ')
 parser.add_argument('-value_model', type=str, default='', help=' ')
 parser.add_argument('-policy_model', type=str, default='', help=' ')
 parser.add_argument('-save_sim_video', action='store_true', help='Save simulator video in <frames> info attribute')
+parser.add_argument('-tensorboard_dir', type=str, default='models/policy_networks',
+                    help='path to the directory where to save tensorboard log. If passed empty path' \
+                         ' no logs are saved.')
 
 opt = parser.parse_args()
 
@@ -175,7 +178,10 @@ print(f'[saving to {path.join(opt.save_dir, plan_file)}]')
 # different performance metrics
 time_travelled, distance_travelled, road_completed, action_sequences, state_sequences = [], [], [], [], []
 
+writer = utils.create_tensorboard_writer(opt)
+
 n_test = len(splits['test_indx'])
+outcomes = []
 for j in range(n_test):
     movie_dir = path.join(opt.save_dir, 'videos_simulator', plan_file, f'ep{j + 1}')
     print(f'[new episode, will save to: {movie_dir}]')
@@ -190,6 +196,8 @@ for j in range(n_test):
     input_state_t0 = inputs['state'].contiguous()[-1]
     action_sequences.append([])
     state_sequences.append([])
+    has_collided = False
+    off_screen = False
     while not done:
         input_images = inputs['context'].contiguous()
         input_states = inputs['state'].contiguous()
@@ -237,11 +245,13 @@ for j in range(n_test):
         while (t < T) and not done:
             inputs, cost, done, info = env.step(a[t])
             if info.collisions_per_frame > 0:
+                has_collided = True
                 print(f'[collision after {cntr} frames, ending]')
                 done = True
             print('(action: ({:.4f}, {:.4f}) | true costs: ({:.4f}, {:.4f})]'.format(
                 a[t][0], a[t][1], cost['pixel_proximity_cost'], cost['lane_cost'])
             )
+            off_screen = info.off_screen
 
             images.append(input_images[-1])
             states.append(input_states[-1])
@@ -286,12 +296,30 @@ for j in range(n_test):
     else:
         mu_list, std_list = None, None
 
+    outcome = 0
+    if has_collided:
+        outcome = 1
+    if off_screen:
+        outcome = 2
+
     if len(images) > 3:
         utils.save_movie(path.join(movie_dir, 'ego'), images.float() / 255.0, states, costs,
                          actions=actions, mu=mu_list, std=std_list, pytorch=True)
+        outcomes.append(outcome)
+        if writer is not None:
+            writer.add_video(f'Video/success={road_completed[-1]:d}_{j}', images.unsqueeze(0), j)
+            writer.add_scalar('ByEpisode/Success', road_completed[-1], j)
+            writer.add_scalar('ByEpisode/Collision', has_collided, j)
+            writer.add_scalar('ByEpisode/OffScreen', off_screen, j)
+            writer.add_scalar('ByEpisode/Distance', distance_travelled[-1], j)
         if opt.save_sim_video:
             sim_path = path.join(movie_dir, 'sim')
             print(f'[saving simulator movie to {sim_path}]')
             os.mkdir(sim_path)
             for n, img in enumerate(info.frames):
                 imwrite(path.join(sim_path, f'im{n:05d}.png'), img)
+
+if writer is not None:
+    writer.add_histogram('Success/Hist', road_completed)
+    writer.add_histogram('Success/Outcomes', outcomes)
+    writer.close()

--- a/train_IL.py
+++ b/train_IL.py
@@ -4,6 +4,7 @@ import models
 from dataloader import DataLoader
 import torch.nn.functional as F
 import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
 
 
 ###########################################
@@ -35,6 +36,8 @@ parser.add_argument('-epoch_size', type=int, default=1000)
 parser.add_argument('-combine', type=str, default='add')
 parser.add_argument('-grad_clip', type=float, default=50)
 parser.add_argument('-debug', action='store_true')
+parser.add_argument('-tensorboard_dir', type=str, default=None,
+                    help='path to the directory where to save tensorboard log')
 opt = parser.parse_args()
 
 
@@ -103,6 +106,7 @@ def test(nbatches):
 
 
 
+writer = SummaryWriter(log_dir=opt.tensorboard_dir)
 print('[training]')
 best_valid_loss = 1e6
 for i in range(200):
@@ -114,6 +118,11 @@ for i in range(200):
         torch.save(policy, opt.model_file + '.model')
         policy.intype('gpu')
 
+    writer.add_scalar('Loss/train', train_loss, i)
+    writer.add_scalar('Loss/valid', valid_loss, i)
+
     log_string = f'iter {opt.epoch_size*i} | train loss: {train_loss:.5f}, valid: {valid_loss:.5f}, best valid loss: {best_valid_loss:.5f}'
     print(log_string)
     utils.log(opt.model_file + '.log', log_string)
+
+writer.close()

--- a/train_IL.py
+++ b/train_IL.py
@@ -4,7 +4,6 @@ import models
 from dataloader import DataLoader
 import torch.nn.functional as F
 import torch.optim as optim
-from torch.utils.tensorboard import SummaryWriter
 
 
 ###########################################
@@ -36,8 +35,9 @@ parser.add_argument('-epoch_size', type=int, default=1000)
 parser.add_argument('-combine', type=str, default='add')
 parser.add_argument('-grad_clip', type=float, default=50)
 parser.add_argument('-debug', action='store_true')
-parser.add_argument('-tensorboard_dir', type=str, default=None,
-                    help='path to the directory where to save tensorboard log')
+parser.add_argument('-tensorboard_dir', type=str, default='models/policy_networks',
+                    help='path to the directory where to save tensorboard log. If passed empty path' \
+                         ' no logs are saved.')
 opt = parser.parse_args()
 
 
@@ -105,8 +105,8 @@ def test(nbatches):
 
 
 
+writer = utils.create_tensorboard_writer(opt)
 
-writer = SummaryWriter(log_dir=opt.tensorboard_dir)
 print('[training]')
 best_valid_loss = 1e6
 for i in range(200):
@@ -118,11 +118,13 @@ for i in range(200):
         torch.save(policy, opt.model_file + '.model')
         policy.intype('gpu')
 
-    writer.add_scalar('Loss/train', train_loss, i)
-    writer.add_scalar('Loss/valid', valid_loss, i)
+    if writer is not None:
+        writer.add_scalar('Loss/train', train_loss, i)
+        writer.add_scalar('Loss/valid', valid_loss, i)
 
     log_string = f'iter {opt.epoch_size*i} | train loss: {train_loss:.5f}, valid: {valid_loss:.5f}, best valid loss: {best_valid_loss:.5f}'
     print(log_string)
     utils.log(opt.model_file + '.log', log_string)
 
-writer.close()
+    if writer is not None:
+        writer.close()

--- a/train_MPER.py
+++ b/train_MPER.py
@@ -3,6 +3,7 @@ import utils
 from dataloader import DataLoader
 import torch.nn.functional as F
 import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
 import models, planning
 import importlib
 
@@ -54,6 +55,8 @@ parser.add_argument('-load_model_file', type=str, default='')
 parser.add_argument('-combine', type=str, default='add')
 parser.add_argument('-debug', action='store_true')
 parser.add_argument('-test_only', type=int, default=0)
+parser.add_argument('-tensorboard_dir', type=str, default=None,
+                    help='path to the directory where to save tensorboard log')
 opt = parser.parse_args()
 
 opt.n_inputs = 4
@@ -236,6 +239,7 @@ if opt.test_only == 1:
     print('[testing]')
     valid_losses = test(10, 200)
 else:
+    writer = SummaryWriter(log_dir=opt.tensorboard_dir)
     print('[training]')
     utils.log(opt.model_file + '.log', f'[job name: {opt.model_file}]')
     npred = opt.npred if opt.npred != -1 else 16
@@ -254,6 +258,19 @@ else:
                     'n_iter': n_iter},
                    opt.model_file + '.model')
         model.intype('gpu')
+
+        writer.add_scalar('Loss/train_state_img', train_losses[0], i)
+        writer.add_scalar('Loss/train_state_vct', train_losses[1], i)
+        writer.add_scalar('Loss/train_costs', train_losses[2], i)
+        writer.add_scalar('Loss/train_policy', train_losses[3], i)
+        writer.add_scalar('Loss/train_relative_entropy', train_losses[4], i)
+
+        writer.add_scalar('Loss/validation_state_img', valid_losses[0], i)
+        writer.add_scalar('Loss/validation_state_vct', valid_losses[1], i)
+        writer.add_scalar('Loss/validation_costs', valid_losses[2], i)
+        writer.add_scalar('Loss/validation_policy', valid_losses[3], i)
+        writer.add_scalar('Loss/validation_relative_entropy', valid_losses[4], i)
+
         log_string = f'step {n_iter} | npred {npred} | bsize {bsize} | esize {opt.epoch_size} | '
         log_string += utils.format_losses(train_losses[0], train_losses[1], split='train')
         log_string += utils.format_losses(valid_losses[0], valid_losses[1], split='valid')
@@ -261,4 +278,6 @@ else:
         utils.log(opt.model_file + '.log', log_string)
         if i > 0 and(i % opt.curriculum_length == 0) and (opt.npred == -1) and npred < 400:
             npred += 8
+
+    writer.close()
 

--- a/train_MPUR.py
+++ b/train_MPUR.py
@@ -7,7 +7,6 @@ import ipdb
 import random
 import torch
 import torch.optim as optim
-from torch.utils.tensorboard import SummaryWriter
 from os import path
 
 import planning
@@ -133,17 +132,18 @@ losses = OrderedDict(
     π='policy',
 )
 
-writer = SummaryWriter(log_dir=opt.tensorboard_dir)
+writer = utils.create_tensorboard_writer(opt)
 
 for i in range(500):
     train_losses = start('train', opt.epoch_size, opt.npred)
     with torch.no_grad():  # Torch, please please please, do not track computations :)
         valid_losses = start('valid', opt.epoch_size // 2, opt.npred)
 
-    for key in train_losses:
-        writer.add_scalar(f'Loss/train_{key}', train_losses[key], i)
-    for key in valid_losses:
-        writer.add_scalar(f'Loss/valid_{key}', valid_losses[key], i)
+    if writer is not None:
+        for key in train_losses:
+            writer.add_scalar(f'Loss/train_{key}', train_losses[key], i)
+        for key in valid_losses:
+            writer.add_scalar(f'Loss/valid_{key}', valid_losses[key], i)
 
     n_iter += opt.epoch_size
     model.to('cpu')
@@ -169,4 +169,5 @@ for i in range(500):
     print(log_string)
     utils.log(opt.model_file + '.log', log_string)
 
-writer.close()
+if writer is not None:
+    writer.close()

--- a/train_cost.py
+++ b/train_cost.py
@@ -3,6 +3,7 @@ import utils
 from dataloader import DataLoader
 import torch.nn.functional as F
 import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
 import importlib
 import models
 import torch.nn as nn
@@ -31,6 +32,8 @@ parser.add_argument('-epoch_size', type=int, default=1000)
 parser.add_argument('-mfile', type=str, default='model=fwd-cnn-vae-fp-layers=3-bsize=64-ncond=20-npred=20-lrt=0.0001-nfeature=256-dropout=0.1-nz=32-beta=1e-06-zdropout=0.5-gclip=5.0-warmstart=1-seed=1.step200000.model')
 #parser.add_argument('-mfile', type=str, default='model=fwd-cnn-layers=3-bsize=64-ncond=20-npred=20-lrt=0.0001-nfeature=256-dropout=0.1-gclip=5.0-warmstart=0-seed=1.step200000.model')
 parser.add_argument('-debug', action='store_true')
+parser.add_argument('-tensorboard_dir', type=str, default=None,
+                    help='path to the directory where to save tensorboard log')
 opt = parser.parse_args()
 
 os.system('mkdir -p ' + opt.model_dir)
@@ -101,7 +104,7 @@ def test(nbatches, npred):
     return total_loss
 
 
-
+writer = SummaryWriter(log_dir=opt.tensorboard_dir)
 
 print('[training]')
 n_iter = 0
@@ -120,7 +123,10 @@ for i in range(200):
                     'n_iter': n_iter}, opt.model_file + f'.step{n_iter}.model')
         torch.save(model, opt.model_file + f'.step{n_iter}.model')
     model.intype('gpu')
+    writer.add_scalar('Loss/train', train_loss, i)
+    writer.add_scalar('Loss/valid', valid_loss, i)
     log_string = f'step {n_iter} | train: {train_loss} | valid: {valid_loss}' 
     print(log_string)
     utils.log(opt.model_file + '.log', log_string)
 
+writer.close()

--- a/train_cost.py
+++ b/train_cost.py
@@ -3,10 +3,10 @@ import utils
 from dataloader import DataLoader
 import torch.nn.functional as F
 import torch.optim as optim
-from torch.utils.tensorboard import SummaryWriter
 import importlib
 import models
 import torch.nn as nn
+import utils
 
 #################################################
 # Train an action-conditional forward model
@@ -32,8 +32,9 @@ parser.add_argument('-epoch_size', type=int, default=1000)
 parser.add_argument('-mfile', type=str, default='model=fwd-cnn-vae-fp-layers=3-bsize=64-ncond=20-npred=20-lrt=0.0001-nfeature=256-dropout=0.1-nz=32-beta=1e-06-zdropout=0.5-gclip=5.0-warmstart=1-seed=1.step200000.model')
 #parser.add_argument('-mfile', type=str, default='model=fwd-cnn-layers=3-bsize=64-ncond=20-npred=20-lrt=0.0001-nfeature=256-dropout=0.1-gclip=5.0-warmstart=0-seed=1.step200000.model')
 parser.add_argument('-debug', action='store_true')
-parser.add_argument('-tensorboard_dir', type=str, default=None,
-                    help='path to the directory where to save tensorboard log')
+parser.add_argument('-tensorboard_dir', type=str, default='models',
+                    help='path to the directory where to save tensorboard log. If passed empty path' \
+                         ' no logs are saved.')
 opt = parser.parse_args()
 
 os.system('mkdir -p ' + opt.model_dir)
@@ -103,8 +104,8 @@ def test(nbatches, npred):
     total_loss /= nbatches
     return total_loss
 
+writer = utils.create_tensorboard_writer(opt)
 
-writer = SummaryWriter(log_dir=opt.tensorboard_dir)
 
 print('[training]')
 n_iter = 0
@@ -123,10 +124,12 @@ for i in range(200):
                     'n_iter': n_iter}, opt.model_file + f'.step{n_iter}.model')
         torch.save(model, opt.model_file + f'.step{n_iter}.model')
     model.intype('gpu')
-    writer.add_scalar('Loss/train', train_loss, i)
-    writer.add_scalar('Loss/valid', valid_loss, i)
+    if writer is not None:
+        writer.add_scalar('Loss/train', train_loss, i)
+        writer.add_scalar('Loss/valid', valid_loss, i)
     log_string = f'step {n_iter} | train: {train_loss} | valid: {valid_loss}' 
     print(log_string)
     utils.log(opt.model_file + '.log', log_string)
 
-writer.close()
+if writer is not None:
+    writer.close()

--- a/train_fm.py
+++ b/train_fm.py
@@ -6,6 +6,11 @@ import torch.optim as optim
 import importlib
 import models
 import torch.nn as nn
+from torch.utils.tensorboard import SummaryWriter
+
+
+torch.backends.cudnn.deterministic = True
+torch.backends.cudnn.benchmark = False
 
 #################################################
 # Train an action-conditional forward model
@@ -34,6 +39,8 @@ parser.add_argument('-grad_clip', type=float, default=5.0)
 parser.add_argument('-epoch_size', type=int, default=2000)
 parser.add_argument('-warmstart', type=int, default=0, help='initialize with pretrained model')
 parser.add_argument('-debug', action='store_true')
+parser.add_argument('-tensorboard_dir', type=str, default=None,
+                    help='path to the directory where to save tensorboard log')
 opt = parser.parse_args()
 
 os.system('mkdir -p ' + opt.model_dir)
@@ -109,7 +116,7 @@ model.cuda()
 # training and testing functions. We will compute several losses:
 # loss_i: images
 # loss_s: states
-# loss_p: prior (optional)
+# loss_p: relative entropy (optional)
 
 def compute_loss(targets, predictions, reduction='mean'):
     target_images = targets[0]
@@ -189,12 +196,22 @@ def test(nbatches):
     total_loss_p /= nbatches
     return total_loss_i, total_loss_s, total_loss_p
 
+writer = SummaryWriter(log_dir=opt.tensorboard_dir)
 
 print('[training]')
 for i in range(200):
     t0 = time.time()
     train_losses = train(opt.epoch_size, opt.npred)
     valid_losses = test(int(opt.epoch_size / 2))
+
+    writer.add_scalar('Loss/train_state_img', train_losses[0], i)
+    writer.add_scalar('Loss/train_state_vct', train_losses[1], i)
+    writer.add_scalar('Loss/train_relative_entropy', train_losses[2], i)
+
+    writer.add_scalar('Loss/validation_state_img', valid_losses[0], i)
+    writer.add_scalar('Loss/validation_state_vct', valid_losses[1], i)
+    writer.add_scalar('Loss/validation_relative_entropy', valid_losses[2], i)
+
     n_iter += opt.epoch_size
     model.cpu()
     torch.save({'model': model,
@@ -209,3 +226,4 @@ for i in range(200):
     print(log_string)
     utils.log(opt.model_file + '.log', log_string)
 
+writer.close()

--- a/utils.py
+++ b/utils.py
@@ -501,6 +501,8 @@ def parse_command_line(parser=None):
     parser.add_argument('-save_movies', action='store_true')
     parser.add_argument('-l2reg', type=float, default=0.0)
     parser.add_argument('-no_cuda', action='store_true')
+    parser.add_argument('-tensorboard_dir', type=str, default=None,
+                        help='path to the directory where to save tensorboard log')
     opt = parser.parse_args()
     opt.n_inputs = 4
     opt.n_actions = 2

--- a/utils.py
+++ b/utils.py
@@ -547,7 +547,7 @@ def build_model_file_name(opt):
 def create_tensorboard_writer(opt):
     tensorboard_enabled = opt.tensorboard_dir != ''
     if tensorboard_enabled:
-        date_str = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        date_str = datetime.now().strftime('%Y_%m_%d_%H_%M_%S')
         if hasattr(opt, 'model_file'):
             model_name = os.path.basename(opt.model_file)
         elif hasattr(opt, 'mfile'):
@@ -555,7 +555,7 @@ def create_tensorboard_writer(opt):
         else:
             raise AttributeError("options doesn't contain neither model_file nor mfile field")
         script_name = os.path.splitext(sys.argv[0])[0]
-        tensorboard_log_dir = os.path.join(opt.tensorboard_dir, 'tb_log_{}_{}_{}'.format(script_name, model_name, date_str))
+        tensorboard_log_dir = os.path.join(opt.tensorboard_dir, f'tb_log_{script_name}_{model_name}_{date_str}')
         print('saving tensorboard logs to', tensorboard_log_dir)
         writer = SummaryWriter(log_dir=tensorboard_log_dir)
         return writer


### PR DESCRIPTION
Added tensorboard support to:
* `train_fm.py`
* `train_MPER.py`
* `train_MPUR.py`
* `train_IL.py`
* `eval_policy.py`

Also updated `environment.yaml` to support the tensorboard, which entailed using pytorch 1.2.0

Default path for logs directory is in `models/` or in `models/policy_networks`.
To run tensorboard, just run `tensorboard --log-dir models` or `tensorboard --log-dir policy_networks`, depending on what results you want to see.

That script runs a server for the web-page which can be accessed at `localhost:6006`. If you run it on a remote machine, you can use ssh port tunneling to access the page.