### PR TITLE
Removed Mail Addresses in Slurm Scripts

### DIFF
--- a/scripts/notif_config
+++ b/scripts/notif_config
@@ -1,2 +1,0 @@
-# enter your mail address below
-emailaddress=emailaddress

--- a/scripts/notif_config
+++ b/scripts/notif_config
@@ -1,0 +1,2 @@
+# enter your mail address below
+emailaddress=emailaddress

--- a/scripts/submit_eval_fm.slurm
+++ b/scripts/submit_eval_fm.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=eval_fm
 #SBATCH --output=eval_fm.out
 #SBATCH --error=eval_fm.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_eval_fm.slurm
+++ b/scripts/submit_eval_fm.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=eval_fm
 #SBATCH --output=eval_fm.out
 #SBATCH --error=eval_fm.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_eval_mpur.slurm
+++ b/scripts/submit_eval_mpur.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=eval_MPUR
 #SBATCH --output=logs/eval_MPUR_%j.out
 #SBATCH --error=logs/eval_MPUR_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_eval_mpur.slurm
+++ b/scripts/submit_eval_mpur.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=eval_MPUR
 #SBATCH --output=logs/eval_MPUR_%j.out
 #SBATCH --error=logs/eval_MPUR_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_generate_data.slurm
+++ b/scripts/submit_generate_data.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=datagen
 #SBATCH --output=datagen.out
 #SBATCH --error=datagen.err
@@ -10,7 +11,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 source activate py35
 cd ../

--- a/scripts/submit_generate_data.slurm
+++ b/scripts/submit_generate_data.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=datagen
 #SBATCH --output=datagen.out
 #SBATCH --error=datagen.err
@@ -11,7 +10,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 source activate py35
 cd ../

--- a/scripts/submit_generate_data_i80.slurm
+++ b/scripts/submit_generate_data_i80.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=i80-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -9,7 +8,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map i80

--- a/scripts/submit_generate_data_i80.slurm
+++ b/scripts/submit_generate_data_i80.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=i80-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -8,7 +9,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map i80

--- a/scripts/submit_generate_data_lanker.slurm
+++ b/scripts/submit_generate_data_lanker.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=lanker-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -8,7 +9,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map lanker

--- a/scripts/submit_generate_data_lanker.slurm
+++ b/scripts/submit_generate_data_lanker.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=lanker-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -9,7 +8,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map lanker

--- a/scripts/submit_generate_data_peach.slurm
+++ b/scripts/submit_generate_data_peach.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=peach-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -9,7 +8,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map peach

--- a/scripts/submit_generate_data_peach.slurm
+++ b/scripts/submit_generate_data_peach.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=peach-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -8,7 +9,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map peach

--- a/scripts/submit_generate_data_us101.slurm
+++ b/scripts/submit_generate_data_us101.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=us101-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -9,7 +8,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map us101

--- a/scripts/submit_generate_data_us101.slurm
+++ b/scripts/submit_generate_data_us101.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=us101-datagen
 #SBATCH --time=24:00:00
 #SBATCH --gres gpu:0
@@ -8,7 +9,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python -u generate_trajectories.py -time_slot $time_slot -map us101

--- a/scripts/submit_plan.slurm
+++ b/scripts/submit_plan.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=plan
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -mfile $1 -model_dir $2 -n_rollouts $3 -rollout_length $4 -bprop_lrt $5 -bprop_niter $6 -method $7

--- a/scripts/submit_plan.slurm
+++ b/scripts/submit_plan.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=plan
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -mfile $1 -model_dir $2 -n_rollouts $3 -rollout_length $4 -bprop_lrt $5 -bprop_niter $6 -method $7

--- a/scripts/submit_plan_bprop.slurm
+++ b/scripts/submit_plan_bprop.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=plan
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -method $1 -bprop_niter $2 -bprop_lrt $3 -u_reg $4 -u_hinge $5 -bprop_buffer $6 -lambda_l $7

--- a/scripts/submit_plan_bprop.slurm
+++ b/scripts/submit_plan_bprop.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=plan
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -method $1 -bprop_niter $2 -bprop_lrt $3 -u_reg $4 -u_hinge $5 -bprop_buffer $6 -lambda_l $7

--- a/scripts/submit_plan_policy.slurm
+++ b/scripts/submit_plan_policy.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=plan_policy
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -method $1 -model_dir $2 -policy_model_tm $3

--- a/scripts/submit_plan_policy.slurm
+++ b/scripts/submit_plan_policy.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=plan_policy
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -method $1 -model_dir $2 -policy_model_tm $3

--- a/scripts/submit_plan_policy_il.slurm
+++ b/scripts/submit_plan_policy_il.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=plan
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -method policy-il -npred 1

--- a/scripts/submit_plan_policy_il.slurm
+++ b/scripts/submit_plan_policy_il.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=plan
 #SBATCH --output=logs/plan_%j.out
 #SBATCH --error=logs/plan_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 cd ../
 srun python plan_with_uncertainty.py -method policy-il -npred 1

--- a/scripts/submit_train_critic.slurm
+++ b/scripts/submit_train_critic.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_critic
 #SBATCH --output=train_critic.out
 #SBATCH --error=train_critic.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_critic.slurm
+++ b/scripts/submit_train_critic.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_critic
 #SBATCH --output=train_critic.out
 #SBATCH --error=train_critic.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_critic_joint.slurm
+++ b/scripts/submit_train_critic_joint.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_critic_joint
 #SBATCH --output=train_critic.out
 #SBATCH --error=train_critic.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_critic_joint.slurm
+++ b/scripts/submit_train_critic_joint.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_critic_joint
 #SBATCH --output=train_critic.out
 #SBATCH --error=train_critic.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=70000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_fm.slurm
+++ b/scripts/submit_train_fm.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_fm_det
 #SBATCH --output=logs/train_fm_%j.out
 #SBATCH --error=logs/train_fm_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=50000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_train_fm.slurm
+++ b/scripts/submit_train_fm.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_fm_det
 #SBATCH --output=logs/train_fm_%j.out
 #SBATCH --error=logs/train_fm_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=50000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_train_il.slurm
+++ b/scripts/submit_train_il.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_il
 #SBATCH --output=train_il.out
 #SBATCH --error=train_il.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_il.slurm
+++ b/scripts/submit_train_il.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_il
 #SBATCH --output=train_il.out
 #SBATCH --error=train_il.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_mb_il.slurm
+++ b/scripts/submit_train_mb_il.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_mb_il
 #SBATCH --output=logs/train_mb_il_%j.out
 #SBATCH --error=logs/train_mb_il_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_mb_il.slurm
+++ b/scripts/submit_train_mb_il.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_mb_il
 #SBATCH --output=logs/train_mb_il_%j.out
 #SBATCH --error=logs/train_mb_il_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_mpur.slurm
+++ b/scripts/submit_train_mpur.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_MPUR
 #SBATCH --output=logs/train_MPUR_%j.out
 #SBATCH --error=logs/train_MPUR_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_train_mpur.slurm
+++ b/scripts/submit_train_mpur.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_MPUR
 #SBATCH --output=logs/train_MPUR_%j.out
 #SBATCH --error=logs/train_MPUR_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=canziani@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 eval "$(conda shell.bash hook)"
 conda activate PPUU

--- a/scripts/submit_train_policy_prior.slurm
+++ b/scripts/submit_train_policy_prior.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_policy_prior
 #SBATCH --output=logs/train_policy_prior_%j.out
 #SBATCH --error=logs/train_policy_prior_%j.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_policy_prior.slurm
+++ b/scripts/submit_train_policy_prior.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_policy_prior
 #SBATCH --output=logs/train_policy_prior_%j.out
 #SBATCH --error=logs/train_policy_prior_%j.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_prior.slurm
+++ b/scripts/submit_train_prior.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_prior
 #SBATCH --output=train_prior.out
 #SBATCH --error=train_prior.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=50000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_prior.slurm
+++ b/scripts/submit_train_prior.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_prior
 #SBATCH --output=train_prior.out
 #SBATCH --error=train_prior.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=50000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_value_fn.slurm
+++ b/scripts/submit_train_value_fn.slurm
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+source notif_config
 #SBATCH --job-name=train_value
 #SBATCH --output=train_value.out
 #SBATCH --error=train_value.err
@@ -11,7 +12,7 @@
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user=mbh305@nyu.edu
+#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../

--- a/scripts/submit_train_value_fn.slurm
+++ b/scripts/submit_train_value_fn.slurm
@@ -1,6 +1,5 @@
 #!/bin/bash
 #
-source notif_config
 #SBATCH --job-name=train_value
 #SBATCH --output=train_value.out
 #SBATCH --error=train_value.err
@@ -12,7 +11,6 @@ source notif_config
 #SBATCH --nodes=1
 #SBATCH --mem=48000
 #SBATCH --mail-type=END,FAIL # notifications for job done & fail
-#SBATCH --mail-user="$emailaddress"
 
 module load python-3.6
 cd ../


### PR DESCRIPTION
By default slurm sends the notification emails to the submitting user. I removed `--mail-users` arguments in the slurm scripts to avoid notification emails being sent to other users.